### PR TITLE
feat: allow only discord users that are part of a certain server

### DIFF
--- a/Discord.php
+++ b/Discord.php
@@ -13,6 +13,7 @@ class Discord extends AbstractOAuth2Base
     // Discord scopes
     const SCOPE_EMAIL = 'email';
     const SCOPE_IDENTIFY = 'identify';
+    const SCOPE_GUILDS = 'guilds';
 
     /**
      * @inheritdoc

--- a/action.php
+++ b/action.php
@@ -8,7 +8,6 @@ use dokuwiki\plugin\oauthdiscord\Discord;
  */
 class action_plugin_oauthdiscord extends Adapter
 {
-
     /**
      * @inheritdoc
      */
@@ -34,6 +33,17 @@ class action_plugin_oauthdiscord extends Adapter
             $data['mail'] = $result['email'];
         }
 
+        $serverId = $this->getConf('serverId');
+        if ($serverId) {
+            $resultGuilds = json_decode($oauth->request('https://discord.com/api/users/@me/guilds'), true);
+
+            $foundServer = array_column($resultGuilds, null, 'id')[$serverId] ?? false;
+
+            if (!$foundServer) {
+                return;
+            }
+        }
+
         return $data;
     }
 
@@ -42,7 +52,7 @@ class action_plugin_oauthdiscord extends Adapter
      */
     public function getScopes()
     {
-        return [Discord::SCOPE_IDENTIFY, Discord::SCOPE_EMAIL];
+        return [Discord::SCOPE_IDENTIFY, Discord::SCOPE_EMAIL, Discord::SCOPE_GUILDS];
     }
 
     /**

--- a/conf/default.php
+++ b/conf/default.php
@@ -5,3 +5,4 @@
 
 $conf['key'] = '';
 $conf['secret'] = '';
+$conf['serverId'] = '';

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -5,3 +5,4 @@
 
 $meta['key'] = array('string');
 $meta['secret'] = array('password');
+$meta['serverId'] = array('string');

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -7,3 +7,4 @@
 
 $lang['key'] = 'The Application UID';
 $lang['secret'] = 'The Application Secret';
+$lang['serverId'] = 'Allow members of specific server only';


### PR DESCRIPTION
Hey, I was missing the option to only allow members of a certain Discord server. I knew that Wiki.JS had this option, so I kinda "copied" the idea and implemented it in your plugin.

The Error message is not ideal so far, because it says: "OAuth: discord service did not provide the an email address. Can't log you in.". Since I don't have much experience with PHP, I hope that you can help me with that, so it's cleaner.

I've tested it in our own Wiki environment with one account who is member of this server and another account who is not part of the server and it behaved as expected.

Thanks in advance